### PR TITLE
APIキーをユーザが設定できるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
         "ts-loader": "^9.4.3",
+        "tsconfig-paths-webpack-plugin": "^4.1.0",
         "typescript": "^5.1.3",
         "webpack": "^5.85.0",
         "webpack-cli": "^5.1.1"
@@ -2409,6 +2410,18 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -2592,6 +2605,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mocha": {
@@ -3585,6 +3607,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3731,6 +3762,34 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
+      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   "contributes": {
     "commands": [
       {
-        "command": "meimei-ai.テスト",
-        "title": "テスト"
+        "command": "meimei-ai.suggest-function-names",
+        "title": "meimei-ai: suggest function names"
       }
     ],
     "menus": {
       "editor/context": [
         {
-          "command": "meimei-ai.テスト",
+          "command": "meimei-ai.suggest-function-names",
           "when": "editorHasSelection"
         }
       ]
@@ -52,6 +52,7 @@
     "glob": "^8.1.0",
     "mocha": "^10.2.0",
     "ts-loader": "^9.4.3",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.1.3",
     "webpack": "^5.85.0",
     "webpack-cli": "^5.1.1"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,20 @@
       {
         "command": "meimei-ai.suggest-function-names",
         "title": "meimei-ai: suggest function names"
+      },
+      {
+        "command": "meimei-ai.change-api-key",
+        "title": "meimei-ai: change api key"
       }
     ],
     "menus": {
       "editor/context": [
         {
           "command": "meimei-ai.suggest-function-names",
+          "when": "editorHasSelection"
+        },
+        {
+          "command": "meimei-ai.change-api-key",
           "when": "editorHasSelection"
         }
       ]

--- a/src/commands/function/prepareApiKey.ts
+++ b/src/commands/function/prepareApiKey.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode";
+
+/**
+ * 保存されているAPIキーを取得する。APIキーが保存されていない場合はユーザに入力させ、保存する
+ * @param context
+ */
+export const prepareApiKey = async (context: vscode.ExtensionContext) => {
+  try {
+    let apiKey = await context.secrets.get("gpt-api-key");
+    if (apiKey) {
+      return apiKey;
+    }
+
+    // The API key has not been set yet, ask the user to input it
+    apiKey = await vscode.window.showInputBox({
+      prompt: "Enter your GPT API key",
+    });
+    if (apiKey) {
+      // If the user provided input, store it as a secret
+      await context.secrets.store("gpt-api-key", apiKey);
+      return apiKey;
+    }
+
+    throw new Error("Failed to get API key");
+  } catch (e: unknown) {
+    throw e;
+    // ユーザにエラーメッセージを表示する
+    vscode.window.showErrorMessage("Failed to get API key");
+  }
+};

--- a/src/commands/function/setApiKey.ts
+++ b/src/commands/function/setApiKey.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode";
+
+/**
+ * APIキーをユーザに入力させ、保存する
+ * @param context
+ */
+export const setApiKey = async (context: vscode.ExtensionContext) => {
+  try {
+    // Show an input box to the user
+    const userInput = await vscode.window.showInputBox({
+      prompt: "Enter your GPT API key",
+    });
+
+    if (userInput) {
+      // If the user provided input, store it as a secret
+      await context.secrets.store("gpt-api-key", userInput);
+    }
+  } catch (e: unknown) {
+    console.log("error: ", e);
+    // ユーザにエラーメッセージを表示する
+    vscode.window.showErrorMessage("Failed to change API key");
+  }
+};

--- a/src/commands/function/suggestFunctionNames.ts
+++ b/src/commands/function/suggestFunctionNames.ts
@@ -1,0 +1,27 @@
+import * as vscode from "vscode";
+import { EditorClient, GptClient } from "~/models";
+
+export const suggestFunctionNames = async () => {
+  const editor = vscode.window.activeTextEditor;
+
+  if (editor) {
+    const editorClient = new EditorClient(editor);
+    const gptClient = new GptClient();
+    const prompt = gptClient.functionNamePrompt(editorClient.getSelectedText());
+
+    try {
+      const suggestionNames = await gptClient.fetchSuggestionNames(prompt);
+
+      // 名前の候補をユーザに提示し、選択させる
+      const pickedName = await editorClient.pickSuggestionName(suggestionNames, "Choose a new function name!");
+
+      if (pickedName) {
+        // ユーザが選択した名前で、選択範囲の「xxx」の部分を置き換える
+        editorClient.replaceWithPickedName(pickedName);
+      }
+    } catch (e: unknown) {
+      console.log("error:", e);
+    }
+  }
+};
+

--- a/src/commands/function/suggestFunctionNames.ts
+++ b/src/commands/function/suggestFunctionNames.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { EditorClient, GptClient } from "~/models";
+import nameSettings from "~/name-settings.json";
 
 export const suggestFunctionNames = async () => {
   const editor = vscode.window.activeTextEditor;
@@ -8,7 +9,8 @@ export const suggestFunctionNames = async () => {
     const editorClient = new EditorClient(editor);
     const gptClient = new GptClient();
     const selectedText = editorClient.getSelectedText();
-    const prompt = gptClient.functionNamePrompt(selectedText);
+    const languageId = editorClient.getSelectedFileLanguageId();
+    const prompt = gptClient.functionNamePrompt(selectedText, languageId, nameSettings);
 
     try {
       const suggestionNames = await gptClient.fetchSuggestionNames(prompt);

--- a/src/commands/function/suggestFunctionNames.ts
+++ b/src/commands/function/suggestFunctionNames.ts
@@ -7,7 +7,8 @@ export const suggestFunctionNames = async () => {
   if (editor) {
     const editorClient = new EditorClient(editor);
     const gptClient = new GptClient();
-    const prompt = gptClient.functionNamePrompt(editorClient.getSelectedText());
+    const selectedText = editorClient.getSelectedText();
+    const prompt = gptClient.functionNamePrompt(selectedText);
 
     try {
       const suggestionNames = await gptClient.fetchSuggestionNames(prompt);
@@ -17,7 +18,7 @@ export const suggestFunctionNames = async () => {
 
       if (pickedName) {
         // ユーザが選択した名前で、選択範囲の「xxx」の部分を置き換える
-        editorClient.replaceWithPickedName(pickedName);
+        editorClient.replaceNameWithPickedName(selectedText, pickedName);
       }
     } catch (e: unknown) {
       console.log("error:", e);

--- a/src/commands/function/suggestFunctionNames.ts
+++ b/src/commands/function/suggestFunctionNames.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
 import { EditorClient, GptClient } from "~/models";
 
-export const suggestFunctionNames = async () => {
+export const suggestFunctionNames = async (context: vscode.ExtensionContext) => {
   const editor = vscode.window.activeTextEditor;
 
   if (editor) {
     const editorClient = new EditorClient(editor);
-    const gptClient = new GptClient();
+    const gptClient = new GptClient(context);
     const selectedText = editorClient.getSelectedText();
     const prompt = gptClient.functionNamePrompt(selectedText);
 
@@ -14,7 +14,10 @@ export const suggestFunctionNames = async () => {
       const suggestionNames = await gptClient.fetchSuggestionNames(prompt);
 
       // 名前の候補をユーザに提示し、選択させる
-      const pickedName = await editorClient.pickSuggestionName(suggestionNames, "Choose a new function name!");
+      const pickedName = await editorClient.pickSuggestionName(
+        suggestionNames,
+        "Choose a new function name!",
+      );
 
       if (pickedName) {
         // ユーザが選択した名前で、選択範囲の「xxx」の部分を置き換える
@@ -25,4 +28,3 @@ export const suggestFunctionNames = async () => {
     }
   }
 };
-

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,1 +1,3 @@
 export { suggestFunctionNames } from "./function/suggestFunctionNames";
+export { prepareApiKey } from "./function/prepareApiKey";
+export { setApiKey } from "./function/setApiKey";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,1 @@
+export { suggestFunctionNames } from "./function/suggestFunctionNames";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,75 +1,8 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-import fetch from "node-fetch";
-(global as any).fetch = fetch;
-import { ChatGPTAPI } from "chatgpt";
-import { FetchGptResponse } from "./types";
-
-const fetchSuggestionNames = async (selectedText: string) => {
-  try {
-    const api = new ChatGPTAPI({
-      apiKey: "自分のAPIキー",
-    });
-    const prompt = `
-      以下の関数の名前の候補を３つ以上考えてください。
-      ###
-        ${selectedText}
-      ###
-
-      候補は以下のjson形式で出力して下さい。
-      ###
-        {
-          "status": "success",
-          "result": string[]
-        }
-      ###
-    `;
-    const res = await api.sendMessage(prompt);
-    const gptResponse: FetchGptResponse = JSON.parse(res.text);
-    const suggestionNames = gptResponse.result;
-    return suggestionNames;
-  } catch (e: unknown) {
-    console.log("エラー", e);
-    throw e;
-  }
-};
-
-const names: string[] = [];
-
-const example = async () => {
-  const editor = vscode.window.activeTextEditor;
-
-  if (editor) {
-    let document = editor.document;
-    let selection = editor.selection;
-
-    // 選択範囲のテキストを取得
-    const text = document.getText(selection);
-
-    try {
-      const suggestionNames = await fetchSuggestionNames(text);
-      // 関数名の候補をユーザに提示し、選択させる
-      let pickedFunctionName = await vscode.window.showQuickPick(suggestionNames, {
-        placeHolder: "Choose a new function name",
-      });
-
-      if (pickedFunctionName) {
-        // ユーザが選択した関数名で、選択範囲の関数名「xxx」の部分を置き換える
-        editor.edit((editBuilder) => {
-          editBuilder.replace(selection, text.replace("xxx", pickedFunctionName!));
-        });
-      }
-    } catch (e: unknown) {
-      console.log("エラー", e);
-    }
-  }
-};
+import { suggestFunctionNames } from "./commands";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand("meimei-ai.テスト", async () => {
-      await example();
-    }),
+    vscode.commands.registerCommand("meimei-ai.suggest-function-names", suggestFunctionNames),
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,17 @@
 import * as vscode from "vscode";
-import { suggestFunctionNames } from "./commands";
+import { suggestFunctionNames, setApiKey } from "./commands";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand("meimei-ai.suggest-function-names", suggestFunctionNames),
+    vscode.commands.registerCommand(
+      "meimei-ai.suggest-function-names",
+      async () => await suggestFunctionNames(context),
+    ),
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "meimei-ai.change-api-key",
+      async () => await setApiKey(context),
+    ),
   );
 }

--- a/src/models/editorClient.ts
+++ b/src/models/editorClient.ts
@@ -1,0 +1,31 @@
+import * as vscode from "vscode";
+
+export class EditorClient {
+  editor: vscode.TextEditor;
+  document: vscode.TextDocument;
+  selection: vscode.Selection;
+
+  constructor(editor: vscode.TextEditor) {
+    this.editor = editor;
+    this.document = editor.document;
+    this.selection = editor.selection;
+  }
+
+  getSelectedText() {
+    return this.document.getText(this.selection);
+  }
+
+  pickSuggestionName(suggestionNames: string[], placeHolder: string) {
+    return vscode.window.showQuickPick(suggestionNames, {
+      placeHolder,
+    });
+  }
+
+  replaceWithPickedName(pickedName: string) {
+    const selectedText = this.getSelectedText();
+
+    this.editor.edit((editBuilder) => {
+      editBuilder.replace(this.selection, selectedText.replace("xxx", pickedName));
+    });
+  }
+}

--- a/src/models/editorClient.ts
+++ b/src/models/editorClient.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import nameSettings from "~/name-settings.json";
 
 export class EditorClient {
   editor: vscode.TextEditor;
@@ -13,6 +14,10 @@ export class EditorClient {
 
   getSelectedText() {
     return this.document.getText(this.selection);
+  }
+
+  getSelectedFileLanguageId() {
+    return this.document.languageId;
   }
 
   pickSuggestionName(suggestionNames: string[], placeHolder: string) {

--- a/src/models/editorClient.ts
+++ b/src/models/editorClient.ts
@@ -21,9 +21,7 @@ export class EditorClient {
     });
   }
 
-  replaceWithPickedName(pickedName: string) {
-    const selectedText = this.getSelectedText();
-
+  replaceNameWithPickedName(selectedText: string, pickedName: string) {
     this.editor.edit((editBuilder) => {
       editBuilder.replace(this.selection, selectedText.replace("xxx", pickedName));
     });

--- a/src/models/gptClient.ts
+++ b/src/models/gptClient.ts
@@ -1,10 +1,17 @@
+import * as vscode from "vscode";
 import fetch from "node-fetch";
 (global as any).fetch = fetch;
 import { ChatGPTAPI } from "chatgpt";
 import { FetchGptResponse } from "~/types";
-
+import { prepareApiKey } from "~/commands";
 
 export class GptClient {
+  context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+  }
+
   functionNamePrompt(selectedFunctionText: string) {
     const prompt = `
       Please come up with six possible names for the following functions and output them in the following json format.
@@ -22,8 +29,9 @@ export class GptClient {
 
   async fetchSuggestionNames(prompt: string) {
     try {
+      const apiKey = await prepareApiKey(this.context);
       const api = new ChatGPTAPI({
-        apiKey: "自分のapikey",
+        apiKey,
       });
       const res = await api.sendMessage(prompt);
       const gptResponse: FetchGptResponse = JSON.parse(res.text);
@@ -33,5 +41,5 @@ export class GptClient {
       console.log("error:", e);
       throw e;
     }
-  };
+  }
 }

--- a/src/models/gptClient.ts
+++ b/src/models/gptClient.ts
@@ -23,7 +23,7 @@ export class GptClient {
   async fetchSuggestionNames(prompt: string) {
     try {
       const api = new ChatGPTAPI({
-        apiKey: "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",
+        apiKey: "自分のapiKey",
       });
       const res = await api.sendMessage(prompt);
       const gptResponse: FetchGptResponse = JSON.parse(res.text);

--- a/src/models/gptClient.ts
+++ b/src/models/gptClient.ts
@@ -1,0 +1,37 @@
+import fetch from "node-fetch";
+(global as any).fetch = fetch;
+import { ChatGPTAPI } from "chatgpt";
+import { FetchGptResponse } from "~/types";
+
+
+export class GptClient {
+  functionNamePrompt(selectedText: string) {
+    const prompt = `
+      Please come up with six possible names for the following functions and output them in the following json format.
+      Don't include any explanations in your responses.
+      \`\`\`
+        ${selectedText}
+      \`\`\`
+
+      \`\`\`json
+        { "result": ["name1", "name2", "name3", "name4", "name5", "name6"] }
+      \`\`\`
+    `;
+    return prompt;
+  }
+
+  async fetchSuggestionNames(prompt: string) {
+    try {
+      const api = new ChatGPTAPI({
+        apiKey: "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",
+      });
+      const res = await api.sendMessage(prompt);
+      const gptResponse: FetchGptResponse = JSON.parse(res.text);
+      const suggestionNames = gptResponse.result;
+      return suggestionNames;
+    } catch (e: unknown) {
+      console.log("error:", e);
+      throw e;
+    }
+  };
+}

--- a/src/models/gptClient.ts
+++ b/src/models/gptClient.ts
@@ -1,22 +1,40 @@
 import fetch from "node-fetch";
 (global as any).fetch = fetch;
 import { ChatGPTAPI } from "chatgpt";
-import { FetchGptResponse } from "~/types";
-
+import { FetchGptResponse, NameSettings, NameSettingsKeys } from "~/types";
 
 export class GptClient {
-  functionNamePrompt(selectedFunctionText: string) {
-    const prompt = `
-      Please come up with six possible names for the following functions and output them in the following json format.
-      Don't include any explanations in your responses.
-      \`\`\`
-        ${selectedFunctionText}
-      \`\`\`
+  functionNamePrompt(selectedFunctionText: string, selectedLanguageId: string, nameSettings: NameSettings) {
+    let prompt: string;
 
-      \`\`\`json
-        { "result": ["name1", "name2", "name3", "name4", "name5", "name6"] }
-      \`\`\`
-    `;
+    if (this.hasNameSettingsOfLanguageId(selectedLanguageId, nameSettings)) {
+      const functionNameSettings = nameSettings[`${selectedLanguageId}`].function;
+      prompt = `
+        Please come up with six possible names for the following ${selectedLanguageId} functions and output them in the following json format.
+        Each name in the array should be a ${functionNameSettings}.
+        Don't include any explanations in your responses.
+        \`\`\`
+          ${selectedFunctionText}
+        \`\`\`
+
+        \`\`\`json
+          { "result": ["name1", "name2", "name3", "name4", "name5", "name6"] }
+        \`\`\`
+      `;
+    } else {
+      prompt = `
+        Please come up with six possible names for the following ${selectedLanguageId} functions and output them in the following json format.
+        Don't include any explanations in your responses.
+        \`\`\`
+          ${selectedFunctionText}
+        \`\`\`
+
+        \`\`\`json
+          { "result": ["name1", "name2", "name3", "name4", "name5", "name6"] }
+        \`\`\`
+      `;
+    }
+
     return prompt;
   }
 
@@ -34,4 +52,9 @@ export class GptClient {
       throw e;
     }
   };
+
+  // todo: このメソッドをこのクラスの中に書くかは悩みどころ。
+  hasNameSettingsOfLanguageId(languageId: string, nameSettings: NameSettings): languageId is NameSettingsKeys {
+    return Object.keys(nameSettings).includes(languageId);
+  }
 }

--- a/src/models/gptClient.ts
+++ b/src/models/gptClient.ts
@@ -5,12 +5,12 @@ import { FetchGptResponse } from "~/types";
 
 
 export class GptClient {
-  functionNamePrompt(selectedText: string) {
+  functionNamePrompt(selectedFunctionText: string) {
     const prompt = `
       Please come up with six possible names for the following functions and output them in the following json format.
       Don't include any explanations in your responses.
       \`\`\`
-        ${selectedText}
+        ${selectedFunctionText}
       \`\`\`
 
       \`\`\`json
@@ -23,7 +23,7 @@ export class GptClient {
   async fetchSuggestionNames(prompt: string) {
     try {
       const api = new ChatGPTAPI({
-        apiKey: "自分のapiKey",
+        apiKey: "自分のapikey",
       });
       const res = await api.sendMessage(prompt);
       const gptResponse: FetchGptResponse = JSON.parse(res.text);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,2 @@
+export { EditorClient } from "./editorClient";
+export { GptClient } from "./gptClient";

--- a/src/name-settings.json
+++ b/src/name-settings.json
@@ -1,0 +1,20 @@
+{
+  "ruby": {
+    "class": "upper camel case",
+    "function": "snake case",
+    "method": "snake case",
+    "variable": "snake case"
+  },
+  "go": {
+    "struct": "upper camel case",
+    "function": "upper camel case",
+    "method": "upper camel case",
+    "variable": "lower camel case"
+  },
+  "typescript": {
+    "class": "upper camel case",
+    "function": "lower camel case",
+    "method": "lower camel case",
+    "variable": "lower camel case"
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,17 @@
+import nameSettings from "name-settings.json";
+
 export type FetchGptResponse = {
   result: string[];
+};
+
+type Nameformat = "lower camel case" | "upper camel case" | "snake case";
+export type NameSettingsKeys = keyof typeof nameSettings;
+export type NameSettings = {
+  [language in NameSettingsKeys]: {
+    class?: Nameformat,
+    struct?: Nameformat,
+    function: Nameformat,
+    method: Nameformat,
+    variable: Nameformat,
+  }
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,3 @@
 export type FetchGptResponse = {
-  status: string;
   result: string[];
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */
 		"baseUrl": "src",
-    "paths": {
-      "~/*": ["*"]
+		"paths": {
+			"~/*": ["*"]
 		},
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
+		"baseUrl": "src",
+    "paths": {
+      "~/*": ["*"]
+		},
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
 			"ES2020",
 			"dom"
 		],
+		"resolveJsonModule": true,
+		"esModuleInterop": true,
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const path = require('path');
 
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
+const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 /** @type WebpackConfig */
 const extensionConfig = {
@@ -25,7 +26,8 @@ const extensionConfig = {
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-    extensions: ['.ts', '.js']
+    extensions: ['.ts', '.js'],
+    plugins: [new TsconfigPathsPlugin({ configFile: './tsconfig.json' })]
   },
   module: {
     rules: [


### PR DESCRIPTION
## やったこと

- APIキーを、ユーザーのマシン上の安全な場所に保存するようにする
  - 命名コマンドを実行したとき、APIキーが保存されていなければ入力ボックスを表示し、ユーザに入力させる
  - change API Keyコマンドを追加し、ユーザがAPIキーを変更できるようにする

## APIキーの保存について

```
秘密情報（例：APIキー）を扱う場合、通常の設定ではなく秘密情報専用のストレージ（VS CodeのSecret Storage API）を利用したほうが安全
```
とのことだったので、Secret Storage APIを利用しています。

### Secret Storage API

秘密情報を安全に保存し、後で取得するための方法を提供するAPI
ユーザーの秘密情報をVS Codeの設定など、安全でない場所に保存するリスクを避けることができる
ただし、VS Codeのバージョン1.53以降でのみ利用可能

## 動作確認

- 初回実行時（suggest-function-namesコマンド）、入力ボックスが表示されること
  - APIキーを入力後、コマンドの内容が実行されること
- change API KeyコマンドでAPIキーを変更できること

## 備考

Lint設定の違いから差分が生じている箇所があります。内容に差分がない所は読み飛ばしてください！