### PR TITLE
APIキーをユーザが設定できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,20 @@
       {
         "command": "meimei-ai.suggest-function-names",
         "title": "meimei-ai: suggest function names"
+      },
+      {
+        "command": "meimei-ai.change-api-key",
+        "title": "meimei-ai: change api key"
       }
     ],
     "menus": {
       "editor/context": [
         {
           "command": "meimei-ai.suggest-function-names",
+          "when": "editorHasSelection"
+        },
+        {
+          "command": "meimei-ai.change-api-key",
           "when": "editorHasSelection"
         }
       ]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,1 +1,2 @@
-export { suggestFunctionNames } from "./function/suggestFunctionNames";
+export { suggestFunctionNames } from "./suggestFunctionNames";
+export { setApiKey } from "./setApiKey";

--- a/src/commands/setApiKey.ts
+++ b/src/commands/setApiKey.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+import { STORE_GPT_API_KEY } from "~/utils/apiKey";
+
+/**
+ * APIキーをユーザに入力させ、保存する
+ * @param context
+ */
+export const setApiKey = async (context: vscode.ExtensionContext) => {
+  try {
+    // Show an input box to the user
+    const userInput = await vscode.window.showInputBox({
+      prompt: "Enter your GPT API key",
+    });
+
+    if (userInput) {
+      // If the user provided input, store it as a secret
+      await context.secrets.store(STORE_GPT_API_KEY, userInput);
+    }
+  } catch (e: unknown) {
+    console.log("error: ", e);
+    // ユーザにエラーメッセージを表示する
+    vscode.window.showErrorMessage("Failed to change API key");
+  }
+};

--- a/src/commands/suggestFunctionNames.ts
+++ b/src/commands/suggestFunctionNames.ts
@@ -3,12 +3,12 @@ import { EditorClient, GptClient } from "~/models";
 import nameSettings from "~/name-settings.json";
 import { NameSettings } from "~/types";
 
-export const suggestFunctionNames = async () => {
+export const suggestFunctionNames = async (context: vscode.ExtensionContext) => {
   const editor = vscode.window.activeTextEditor;
 
   if (editor) {
     const editorClient = new EditorClient(editor);
-    const gptClient = new GptClient();
+    const gptClient = new GptClient(context);
     const selectedText = editorClient.getSelectedText();
     const languageId = editorClient.getSelectedFileLanguageId();
     const prompt = gptClient.namePrompt(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,17 @@
 import * as vscode from "vscode";
-import { suggestFunctionNames } from "./commands";
+import { suggestFunctionNames, setApiKey } from "./commands";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand("meimei-ai.suggest-function-names", suggestFunctionNames),
+    vscode.commands.registerCommand(
+      "meimei-ai.suggest-function-names",
+      async () => await suggestFunctionNames(context),
+    ),
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "meimei-ai.change-api-key",
+      async () => await setApiKey(context),
+    ),
   );
 }

--- a/src/models/gptClient.ts
+++ b/src/models/gptClient.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode";
 import fetch from "node-fetch";
 (global as any).fetch = fetch;
 import { ChatGPTAPI } from "chatgpt";
@@ -9,8 +10,15 @@ import {
   NameTarget,
   nameFormats,
 } from "~/types";
+import { prepareApiKey } from "~/utils/apiKey";
 
 export class GptClient {
+  context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+  }
+
   namePrompt(
     selectedBlock: string,
     selectedLanguageId: string,
@@ -48,8 +56,9 @@ export class GptClient {
 
   async fetchSuggestionNames(prompt: string) {
     try {
+      const apiKey = await prepareApiKey(this.context);
       const api = new ChatGPTAPI({
-        apiKey: "自分のapikey",
+        apiKey,
       });
       const res = await api.sendMessage(prompt);
       const gptResponse: FetchGptResponse = JSON.parse(res.text);

--- a/src/utils/apiKey.ts
+++ b/src/utils/apiKey.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+
+export const STORE_GPT_API_KEY = "meiAI.gpt-api-key";
+
+/**
+ * 保存されているAPIキーを取得する。APIキーが保存されていない場合はユーザに入力させ、保存する
+ * @param context
+ */
+export const prepareApiKey = async (context: vscode.ExtensionContext) => {
+  try {
+    let apiKey = await context.secrets.get(STORE_GPT_API_KEY);
+    if (apiKey) {
+      return apiKey;
+    }
+
+    // The API key has not been set yet, ask the user to input it
+    apiKey = await vscode.window.showInputBox({
+      prompt: "Enter your GPT API key",
+    });
+    if (apiKey) {
+      // If the user provided input, store it as a secret
+      await context.secrets.store(STORE_GPT_API_KEY, apiKey);
+      return apiKey;
+    }
+
+    throw new Error("Failed to get API key");
+  } catch (e: unknown) {
+    // ユーザにエラーメッセージを表示する
+    vscode.window.showErrorMessage("Failed to get API key");
+    throw e;
+  }
+};


### PR DESCRIPTION
## やったこと

- APIキーを、ユーザーのマシン上の安全な場所に保存するようにする
  - 命名コマンドを実行したとき、APIキーが保存されていなければ入力ボックスを表示し、ユーザに入力させる
  - change API Keyコマンドを追加し、ユーザがAPIキーを変更できるようにする

## APIキーの保存について

```
秘密情報（例：APIキー）を扱う場合、通常の設定ではなく秘密情報専用のストレージ（VS CodeのSecret Storage API）を利用したほうが安全
```
とのことだったので、Secret Storage APIを利用しています。

### Secret Storage API

秘密情報を安全に保存し、後で取得するための方法を提供するAPI
ユーザーの秘密情報をVS Codeの設定など、安全でない場所に保存するリスクを避けることができる
ただし、VS Codeのバージョン1.53以降でのみ利用可能

## 動作確認

- 初回実行時（suggest-function-namesコマンド）、入力ボックスが表示されること
  - APIキーを入力後、コマンドの内容が実行されること
- change API KeyコマンドでAPIキーを変更できること

## 備考

Lint設定の違いから差分が生じている箇所があります。内容に差分がない所は読み飛ばしてください！